### PR TITLE
fix(linkwarner): catch `NotFound` exception when removing message

### DIFF
--- a/linkwarner/linkwarner.py
+++ b/linkwarner/linkwarner.py
@@ -478,6 +478,8 @@ class LinkWarner(commands.Cog):
                     channel.id,
                     guild.id,
                 )
+            except discord.NotFound:
+                pass # Would've been deleted previously
             msg = channel_data.format_warn_message(message)
             if msg is not None:
                 try:

--- a/linkwarner/linkwarner.py
+++ b/linkwarner/linkwarner.py
@@ -479,7 +479,7 @@ class LinkWarner(commands.Cog):
                     guild.id,
                 )
             except discord.NotFound:
-                pass # Would've been deleted previously
+                pass  # Would've been deleted previously
             msg = channel_data.format_warn_message(message)
             if msg is not None:
                 try:

--- a/linkwarner/linkwarner.py
+++ b/linkwarner/linkwarner.py
@@ -479,7 +479,8 @@ class LinkWarner(commands.Cog):
                     guild.id,
                 )
             except discord.NotFound:
-                pass  # Would've been deleted previously
+                # message had been removed before we got to it
+                pass
             msg = channel_data.format_warn_message(message)
             if msg is not None:
                 try:


### PR DESCRIPTION
Pretty rare exception but given the context of the cog, if the message was not found, it would've been deleted or is inaccessible anyway, so I think we could just pass through the exception without logging anything. Just tried to cover the issue from macejko325#5014 in the cog support server

(Failed checks ill sort em now)

Scanning through the mypy check, seems as if the checks are being raised for different files outside this PR