### PR TITLE
fix(shell): explicative message in case of not found executable

### DIFF
--- a/shell/__init__.py
+++ b/shell/__init__.py
@@ -25,4 +25,5 @@ with open(Path(__file__).parent / "info.json") as fp:
 
 async def setup(bot: Red) -> None:
     cog = Shell(bot)
+    await cog.initialize()
     bot.add_cog(cog)


### PR DESCRIPTION
Add a more explicative message in case of not found executable when running shell command.